### PR TITLE
Downloader, userdata, and runner updates.  Use newer AMI.

### DIFF
--- a/awslogs/awslogs.conf
+++ b/awslogs/awslogs.conf
@@ -1,0 +1,148 @@
+#
+# ------------------------------------------
+# CLOUDWATCH LOGS AGENT CONFIGURATION FILE
+# ------------------------------------------
+#
+# --- DESCRIPTION ---
+# This file is used by the CloudWatch Logs Agent to specify what log data to send to the service and how.
+# You can modify this file at any time to add, remove or change configuration.
+#
+# NOTE: A running agent must be stopped and restarted for configuration changes to take effect.
+#
+# --- CLOUDWATCH LOGS DOCUMENTATION ---
+# https://aws.amazon.com/documentation/cloudwatch/
+#
+# --- CLOUDWATCH LOGS CONSOLE ---
+# https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs:
+#
+# --- AGENT COMMANDS ---
+# To check or change the running status of the CloudWatch Logs Agent, use the following:
+#
+# To check running status: service awslogs status
+# To stop the agent: service awslogs stop
+# To start the agent: service awslogs start
+# To start the agent on server startup: chkconfig awslogs on
+#
+# --- AGENT LOG OUTPUT ---
+# You can find logs for the agent in /var/log/awslogs.log
+#
+
+# ------------------------------------------
+# CONFIGURATION DETAILS
+# ------------------------------------------
+
+[general]
+# Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
+# client side state across its executions.
+state_file = /var/lib/awslogs/agent-state
+
+## Each log file is defined in its own section. The section name doesn't
+## matter as long as its unique within this file.
+#[kern.log]
+#
+## Path of log file for the agent to monitor and upload.
+#file = /var/log/kern.log
+#
+## Name of the destination log group.
+#log_group_name = kern.log
+#
+## Name of the destination log stream. You may use {hostname} to use target machine's hostname.
+#log_stream_name = {instance_id} # Defaults to ec2 instance id
+#
+## Format specifier for timestamp parsing. Here are some sample formats:
+## Use '%b %d %H:%M:%S' for syslog (Apr 24 08:38:42)
+## Use '%d/%b/%Y:%H:%M:%S' for apache log (10/Oct/2000:13:55:36)
+## Use '%Y-%m-%d %H:%M:%S' for rails log (2008-09-08 11:52:54)
+#datetime_format = %b %d %H:%M:%S # Specification details in the table below.
+#
+## A batch is buffered for buffer-duration amount of time or 32KB of log events.
+## Defaults to 5000 ms and its minimum value is 5000 ms.
+#buffer_duration = 5000
+#
+# Use 'end_of_file' to start reading from the end of the file.
+# Use 'start_of_file' to start reading from the beginning of the file.
+#initial_position = start_of_file
+#
+## Encoding of file
+#encoding = utf-8 # Other supported encodings include: ascii, latin-1
+#
+#
+#
+# Following table documents the detailed datetime format specification:
+# ----------------------------------------------------------------------------------------------------------------------
+# Directive     Meaning                                                                                 Example
+# ----------------------------------------------------------------------------------------------------------------------
+# %a            Weekday as locale's abbreviated name.                                                   Sun, Mon, ..., Sat (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %A           Weekday as locale's full name.                                                          Sunday, Monday, ..., Saturday (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %w           Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.                       0, 1, ..., 6
+# ----------------------------------------------------------------------------------------------------------------------
+#  %d           Day of the month as a zero-padded decimal numbers.                                      01, 02, ..., 31
+# ----------------------------------------------------------------------------------------------------------------------
+#  %b           Month as locale's abbreviated name.                                                     Jan, Feb, ..., Dec (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %B           Month as locale's full name.                                                            January, February, ..., December (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %m           Month as a zero-padded decimal number.                                                  01, 02, ..., 12
+# ----------------------------------------------------------------------------------------------------------------------
+#  %y           Year without century as a zero-padded decimal number.                                   00, 01, ..., 99
+# ----------------------------------------------------------------------------------------------------------------------
+#  %Y           Year with century as a decimal number.                                                  1970, 1988, 2001, 2013
+# ----------------------------------------------------------------------------------------------------------------------
+#  %H           Hour (24-hour clock) as a zero-padded decimal number.                                   00, 01, ..., 23
+# ----------------------------------------------------------------------------------------------------------------------
+#  %I           Hour (12-hour clock) as a zero-padded decimal numbers.                                  01, 02, ..., 12
+# ----------------------------------------------------------------------------------------------------------------------
+#  %p           Locale's equivalent of either AM or PM.                                                 AM, PM (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %M           Minute as a zero-padded decimal number.                                                 00, 01, ..., 59
+# ----------------------------------------------------------------------------------------------------------------------
+#  %S           Second as a zero-padded decimal numbers.                                                00, 01, ..., 59
+# ----------------------------------------------------------------------------------------------------------------------
+#  %f           Microsecond as a decimal number, zero-padded on the left.                               000000, 000001, ..., 999999
+# ----------------------------------------------------------------------------------------------------------------------
+#  %z           UTC offset in the form +HHMM or -HHMM (empty string if the the object is naive).        (empty), +0000, -0400, +1030
+# ----------------------------------------------------------------------------------------------------------------------
+#  %j           Day of the year as a zero-padded decimal number.                                        001, 002, ..., 365
+# ----------------------------------------------------------------------------------------------------------------------
+#  %U           Week number of the year (Sunday as the first day of the week) as a zero padded          00, 01, ..., 53
+#               decimal number. All days in a new year preceding the first Sunday are considered
+#               to be in week 0.
+# ----------------------------------------------------------------------------------------------------------------------
+#  %W           Week number of the year (Monday as the first day of the week) as a decimal number.      00, 01, ..., 53
+#               All days in a new year preceding the first Monday are considered to be in week 0.
+# ----------------------------------------------------------------------------------------------------------------------
+#  %c           Locale's appropriate date and time representation.                                      Tue Aug 16 21:30:00 1988 (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+[/var/log/messages]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/messages
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /var/log/messages
+
+[/var/log/dmesg]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/dmesg
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /var/log/dmesg
+
+[/var/log/cloud-init-output.log]
+file = /var/log/cloud-init-output.log
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /var/log/cloud-init-output.log
+
+[/var/log/cloud-init.log]
+file = /var/log/cloud-init.log
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /var/log/cloud-init.log

--- a/backend/resources/userdata.py
+++ b/backend/resources/userdata.py
@@ -12,25 +12,36 @@ sleep 1
 # Load our environment.  Used by runner.
 export aws_region=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//')
 export instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+set +x
+export db_user=$(aws ssm get-parameters --names "db_user" --region us-east-1 --with-decryption --query Parameters[0].Value --output text)
+export db_password=$(aws ssm get-parameters --names "db_password" --region us-east-1 --with-decryption --query Parameters[0].Value --output text)
+export db_host=$(aws ssm get-parameters --names "db_host" --region us-east-1 --with-decryption --query Parameters[0].Value --output text)
+export db_schema=$(aws ssm get-parameters --names "db_schema" --region us-east-1 --with-decryption --query Parameters[0].Value --output text)
+set -x
 
 # Install dependencies
-sudo yum install -y awscli python3 python3-devel python36-devel python36-pip gcc mysql-devel awslogs || ( echo "Failed to install packages." && exit 1 )
+# ami-14c5486b (3.6)
+# sudo yum install -y awscli python3 python3-devel python36-devel python36-pip gcc mysql-devel awslogs || ( echo "Failed to install packages." && exit 1 )
+# ami-b70554c8 (3.7)
+sudo yum install -y awscli awslogs gcc python3 python3-pip python3-setuptools python3-libs python3-devel mysql-devel || ( echo "Failed to install packages." && exit 1 )
 
 # Send logs to CloudWatch
 aws s3 cp s3://{bucket_name}/config/awslogs.conf /etc/awslogs/awslogs.conf
-/etc/init.d/awslogs start
+systemctl start awslogsd
+# /etc/init.d/awslogs start
 
 # Copy data package and runner package
 aws s3 cp s3://{bucket_name}/{bucket_key} /tmp/npi/
 aws s3 cp s3://{bucket_name}/importer.tar.gz /opt
 
 # Install package
-pip-3.6 install /opt/importer.tar.gz
+pip3 install /opt/importer.tar.gz
 PATH=/usr/local/bin:$PATH
 
 # Clean and load CSV file, then mark the object as imported
 ZIP_FILE=$(ls -1 /tmp/npi/*.zip)
 timeout {timeout}m runner-import.py npi all -i $ZIP_FILE -p {period} -t {table_name} -u /tmp/npi/NPPES --bucket-name {bucket_name} --bucket-key {bucket_key}
+aws s3api put-object-tagging --bucket {bucket_name} --key {bucket_key} --tagging 'TagSet=[{{Key=imported,Value=true}}]'
 
 # Terminate the instance
 halt -p

--- a/importer/loaders/npi.py
+++ b/importer/loaders/npi.py
@@ -10,7 +10,6 @@ from importer.sql.npi_create_clean import CREATE_TABLE_SQL
 from importer.sql.npi_insert import INSERT_WEEKLY_QUERY, INSERT_MONTHLY_QUERY
 from importer.sql.checks import DISABLE, ENABLE
 import pandas as pd
-import boto3
 
 class NpiLoader(object):
     """
@@ -219,21 +218,22 @@ class NpiLoader(object):
     def enable_checks(self):
         self.cursor.execute(ENABLE, multi=True)
 
-    def mark_imported(self, bucket, key):
-        """
-        Marks the s3 object as imported.
-        """
-        client = boto3.client('s3')
+    # Do this in userdata instead, so the script isn't dependent on AWS
+    # def mark_imported(self, bucket, key):
+    #     """
+    #     Marks the s3 object as imported.
+    #     """
+    #     client = boto3.client('s3')
 
-        response = client.put_object_tagging(
-            Bucket=bucket,
-            Key=key,
-            Tagging={
-                'TagSet': [
-                    {
-                        'Key': 'imported',
-                        'Value': 'true'
-                    },
-                ]
-            }
-        )
+    #     response = client.put_object_tagging(
+    #         Bucket=bucket,
+    #         Key=key,
+    #         Tagging={
+    #             'TagSet': [
+    #                 {
+    #                     'Key': 'imported',
+    #                     'Value': 'true'
+    #                 },
+    #             ]
+    #         }
+    #     )

--- a/importer/loggers/cloudwatch.py
+++ b/importer/loggers/cloudwatch.py
@@ -21,7 +21,7 @@ class CloudWatchLogger(object):
             self.logger.create_log_stream(logGroupName=self.log_group, logStreamName=self.log_stream)
         except ClientError as e:
             if e.response['Error']['Code'] == 'ResourceAlreadyExistsException':
-                print("Steam already exists, skip creating.")
+                print("Stream already exists, skip creating.")
 
         response = self.logger.describe_log_streams(
             logGroupName=self.log_group,
@@ -39,13 +39,12 @@ class CloudWatchLogger(object):
         if response and "logStreams" in response:
             if len(response.get('logStreams')) > 0:
                 if "uploadSequenceToken" in response['logStreams'][0]:
-                    print("We have a token!")
                     self.token = response['logStreams'][0]['uploadSequenceToken']
 
     def info(self, message):
         timestamp = int(round(time.time() * 1000))
 
-        print(f"group name is {self.log_group}")
+        # print(f"group name is {self.log_group}")
 
         args = {
             "logGroupName": self.log_group,

--- a/serverless.yml
+++ b/serverless.yml
@@ -115,6 +115,7 @@ resources:
         VPCSecurityGroups:
           - ${self:custom.awsRdsSecurityGroup}
         Engine: MySQL
+        EngineVersion: 5.6.29
         MasterUsername: ${self:custom.db_user}
         MasterUserPassword: ${self:custom.db_password}
         PubliclyAccessible: false


### PR DESCRIPTION
Make the download a little more strict.  Don't download files if there are more than 8 (1 monthly + 4 weekly + 1 deactivation + 2 placeholders).  It's just a simple check but it's meant to prevent downloading a bunch of files if something on the site changes, for example if tthe page gets turned into an index of files.

Remove AWS dependencies from the runner, and move them back into userdata.  This includes:
 - SSM data which is now passed from the environment (again)
 - tagging the object as imported

Ideally, the runner shouldn't be dependent on AWS.  (I'm using a Cloudwatch logger, for "all" so that's not entirely true, but this can be turned into a cli switch)

Upgrade to a newer AMI with python 3.7.  The awslogs now need to be started from systemctl